### PR TITLE
Feat/entry component

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/semantic.min.css">
   </head>
   <body>
     <div id="app"></div>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -16,7 +16,9 @@ export class App extends Component {
 
   render() {
     return (
-      <Entries />
+      <div className="ui three column divided grid">
+        <Entries />
+      </div>
     )
   }
 
@@ -29,3 +31,4 @@ const mapStateToProps = (state) => {
 }
 
 export default connect(mapStateToProps)(App);
+

--- a/client/src/components/Entries.jsx
+++ b/client/src/components/Entries.jsx
@@ -1,5 +1,18 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import Entry from './Entry.jsx';
+
+const dummyEntries = [
+  {
+    date: 'Jan 3, 2017', 
+    text: 'Today was a good day. I counted \
+    my money for a few hours and then ate some expensive snails. I love money!'
+  },
+  {
+    date: 'April 6, 2017',
+    text: 'I got a few more people sick today. Awesome! Greed is good baby!'
+  }
+];
 
 export default class Entries extends Component {
   constructor(props) {
@@ -8,8 +21,11 @@ export default class Entries extends Component {
   }
 
   render() {
+    
     return (
-      <div>Entries Component</div>
+      <div>
+        {dummyEntries.map(entry => <Entry date={entry.date} text={entry.text} key={entry.date}/>)}
+      </div>
     )
   }
 }

--- a/client/src/components/Entries.jsx
+++ b/client/src/components/Entries.jsx
@@ -5,12 +5,11 @@ import Entry from './Entry.jsx';
 const dummyEntries = [
   {
     date: 'Jan 3, 2017', 
-    text: 'Today was a good day. I counted \
-    my money for a few hours and then ate some expensive snails. I love money!'
+    text: 'Test entry #1'
   },
   {
     date: 'April 6, 2017',
-    text: 'I got a few more people sick today. Awesome! Greed is good baby!'
+    text: 'Test entry #2'
   }
 ];
 

--- a/client/src/components/Entries.jsx
+++ b/client/src/components/Entries.jsx
@@ -23,7 +23,7 @@ export default class Entries extends Component {
   render() {
     
     return (
-      <div>
+      <div className="eight wide column">
         {dummyEntries.map(entry => <Entry date={entry.date} text={entry.text} key={entry.date}/>)}
       </div>
     )

--- a/client/src/components/Entry.jsx
+++ b/client/src/components/Entry.jsx
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 export default (props) => (
-  <div>
-    <b>Date:</b> {props.date}
-    <b>Text:</b> {props.text}
+  <div class="ui piled container segment">
+    <h4 class="ui header">{props.date}</h4>
+    <p>{props.text}</p>
   </div>
 )
 

--- a/client/src/components/Entry.jsx
+++ b/client/src/components/Entry.jsx
@@ -1,0 +1,10 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+export default (props) => (
+  <div>
+    <b>Date:</b> {props.date}
+    <b>Text:</b> {props.text}
+  </div>
+)
+

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "scripts": {
     "test": "jest",
-    "dev": "webpack -d --watch",
-    "run-dev": "webpack-dev-server",
+    "dev": "webpack-dev-server",
     "start": "node server/server.js",
     "heroku-postbuild": "webpack -p --config ./webpack.prod.config.js --progress",
     "lint": "eslint client server"
@@ -49,8 +48,8 @@
     "eslint-plugin-react": "^6.10.3",
     "jest": "^19.0.2",
     "regenerator-runtime": "^0.10.3",
-    "webpack-dev-server": "^2.4.2"
-    "react-addons-test-utils": "^15.5.0",
+    "webpack-dev-server": "^2.4.2",
+    "react-addons-test-utils": "^15.5.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "test": "jest",
-    "dev": "webpack-dev-server",
+    "client-dev": "webpack-dev-server",
+    "server-dev": "nodemon server/server.js",
     "start": "node server/server.js",
     "heroku-postbuild": "webpack -p --config ./webpack.prod.config.js --progress",
     "lint": "eslint client server"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jest": "^19.0.2",
     "regenerator-runtime": "^0.10.3",
     "webpack-dev-server": "^2.4.2"
+    "react-addons-test-utils": "^15.5.0",
   },
   "babel": {
     "presets": [

--- a/test/client/App.test.js
+++ b/test/client/App.test.js
@@ -3,7 +3,22 @@ import { shallow, mount, render } from 'enzyme';
 
 import { App } from '../../client/src/components/App.jsx';
 
-it('should render without crashing', () => {
-  const wrapper = shallow(<App />);
-});
+describe('App Component', () => {
+  let app;
+
+  beforeEach(() => {
+    app = shallow(<App />);
+  })
+
+  it('should render without crashing', () => {
+    const wrapper = app;
+  });
+
+  it('App renders nested components', () => {
+    expect(app.find('Entries').length).toEqual(1);
+  })
+
+})
+
+
 

--- a/test/client/Entries.test.js
+++ b/test/client/Entries.test.js
@@ -3,6 +3,20 @@ import { shallow, mount, render } from 'enzyme';
 
 import Entries from '../../client/src/components/Entries.jsx';
 
-it('should render without crashing', () => {
-  const wrapper = shallow(<Entries />);
-});
+describe('Entries Component', () => {
+  let entries;
+
+  beforeEach(() => {
+    entries = shallow(<Entries />);
+  })
+
+  it('should render without crashing', () => {
+    const wrapper = entries;
+  });
+
+  it('Entries renders nested components', () => {
+    expect(entries.find('Entry')).toBeDefined();
+  })
+
+})
+

--- a/test/client/Entry.test.js
+++ b/test/client/Entry.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+
+import Entry from '../../client/src/components/Entry.jsx';
+
+describe('Entry Component', () => {
+  let entry;
+
+  beforeEach(() => {
+    entry = mount(<Entry date={'Jan 1, 2017'} text={'I had a good day.'}/>);
+  })
+
+  it('should render without crashing', () => {
+    const wrapper = entry;
+  });
+
+  it('Entry renders a div', () => {
+    expect(entry.find('div').length).toEqual(1);
+  });
+
+  it('Entry requires date and text props', () => {
+    expect(entry.props().date).toBeDefined();
+    expect(entry.props().text).toBeDefined();
+  })
+  
+})
+


### PR DESCRIPTION
Closes #13 

Created an Entries component to render each specific entry. Right now this only displays a given date and text of the entry. I also wrote a few more basic tests for the App, Entry, and Entries components.

The Entries component is currently a column taking up 8/16 of the Grid. Once we add the Sidebar/Timeline component, this Entries component should sit directly in the middle of the page.

I also updated the npm dev script. 