### PR TITLE
Move Trends menu below NavBar

### DIFF
--- a/client/src/components/trends/Index.jsx
+++ b/client/src/components/trends/Index.jsx
@@ -8,7 +8,7 @@ import ViewSelector from './ViewSelector.jsx';
 import { getEmotionCenters } from './bubbleGraph/bubbleUtils.js';
 
 const gridStyle = {
-  marginTop: '14px'
+  marginTop: '67px'
 };
 
 const charts = ['Sentiment Chart', 'Keywords Bubble Chart'];


### PR DESCRIPTION
Move Trends menu so that it renders below the NavBar rather than being hidden by it. 